### PR TITLE
[Fix] Change version to semantic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scorchpoint-theme",
-  "version": "1.1",
+  "version": "1.1.0",
   "description": "",
   "main": "js/scripts.js",
   "scripts": {


### PR DESCRIPTION
Version needed to abide by semantic versioning, else `npm install` wouldn't work.